### PR TITLE
Two small problems.

### DIFF
--- a/gist.el
+++ b/gist.el
@@ -216,7 +216,7 @@ With a prefix argument, makes a private paste."
   (interactive "P")
   (condition-case nil
       (gist-region (point) (mark) private)
-      (mark-inactive (gist-buffer private))))
+    (error (gist-buffer private))))
 
 ;;;###autoload
 (defun gist-region-or-buffer-private ()
@@ -225,7 +225,7 @@ Copies the URL into the kill ring."
   (interactive)
   (condition-case nil
       (gist-region-private (point) (mark))
-      (mark-inactive (gist-buffer-private))))
+    (error (gist-buffer-private))))
 
 (defvar gist-fetch-url "https://gist.github.com/%d.txt"
   "Raw Gist content URL format")


### PR DESCRIPTION
Hi,

I've got those two errors preventing me to use the gist.el:
- in org mode i can edit code in buffer (babel), but file extension was not right for sending the gist (fix)
- mark-inactive is not working on GNU Emacs 24.0.90.1 (amd64-portbld-freebsd9.0, Motif Version 2.3.3).  Don't know why.

Best regards,
