### PR TITLE
Bug when executable path contains spaces.

### DIFF
--- a/gist.el
+++ b/gist.el
@@ -154,13 +154,13 @@ Copies the URL into the kill ring."
   (let ((strip (lambda (string)
                  (if (> (length string) 0)
                      (substring string 0 (- (length string) 1)))))
-        (git (executable-find "git")))
+        (git (concat "\"" (executable-find "git") "\""))
   (funcall strip (shell-command-to-string
                   (concat git " config --global github." key)))))
 
 (defun github-set-config (key value)
   "Sets a GitHub specific value to the global Git config."
-  (let ((git (executable-find "git")))
+  (let ((git (concat "\"" (executable-find "git") "\"")))
     (shell-command-to-string
      (format git " config --global github.%s %s" key value))))
 


### PR DESCRIPTION
On windows, executable find returns something like "c:/Program Files (x86)/Git/bin/git.exe" which when passed to shell-command-to-string causes an issue because the full path contains spaces. Wrapping this in quotes fixes the issue.

Example in cmd prompt:

C:\Users\jaskirat>c:\Program Files (x86)\Git\bin\git.exe
'c:\Program' is not recognized as an internal or external command,
operable program or batch file.

Therefore when i eval github-auth-info i get ("'c:\Program' is not recognized as an internal or external command,operable program or batch file." . "'c:\Program' is not recognized as an internal or external command,
operable program or batch file.")

After wrapping the command it quotes it works fine.
