### PR TITLE
gist-add-buffer: Invalid Slot Type

### DIFF
--- a/gist.el
+++ b/gist.el
@@ -374,7 +374,7 @@ for the gist."
   (let* ((buffer (get-buffer buffer))
          (id (tabulated-list-get-id))
          (gist (gist-list-db-get-gist id))
-         (fname (or (buffer-file-name buffer) (buffer-name buffer))))
+         (fname (file-name-nondirectory (or (buffer-file-name buffer) (buffer-name buffer)))))
     (let* ((g (clone gist :files
                      (list
                       (gh-gist-gist-file "file"


### PR DESCRIPTION
Whenever I try to add a new buffer to an existing gist, I get the error:

```
byte-code: Invalid slot type: gh-gist-gist, id, string, nil
```

The weird thing is that this error only seems to occur when I add a buffer that exists on disk.  If I add a buffer like _scratch_ or _Messages_, it works just fine.

I created the gist through the dired integration, so some of this is working just fine for me.

Please let me know what sort of debugging information I can provide to assist you.
