### PR TITLE
Fix dependencies

### DIFF
--- a/gist.el
+++ b/gist.el
@@ -10,7 +10,7 @@
 ;; Dan McKinley
 ;; Version: 1.2.1
 ;; Keywords: gist git github paste pastie pastebin
-;; Package-Requires: ((eieio "1.4") (gh "0.8.1") (tabulated-list "0"))
+;; Package-Requires: ((emacs "24.1") (gh "0.8.1"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
Neither `eieio` nor `tabulated-list` are installable packages, so depending on them leads to odd installation failures in some cases: https://github.com/purcell/emacs.d/issues/255

This commit declares a dependency on Emacs 24 instead.