### PR TITLE
Improve support for Emacs' Customize facility

### DIFF
--- a/gist.el
+++ b/gist.el
@@ -48,7 +48,7 @@
 (require 'tabulated-list)
 
 (defgroup gist nil
-  "Gist"
+  "Interface to GitHub's Gist."
   :group 'applications)
 
 (defcustom gist-list-format '((id "Id" 10 nil identity)
@@ -58,7 +58,7 @@
                                             (or (and public "public")
                                                 "private")))
                               (description "Description" 0 nil identity))
-  "Format for gist list"
+  "Format for gist list."
   :type '(alist :key-type
           (choice
            (const :tag "Id" id)
@@ -77,49 +77,58 @@
   :group 'gist)
 
 (defcustom gist-view-gist nil
-  "If non-nil, automatically use `browse-url' to view gists after
-they're posted.")
+  "If non-nil, view gists with `browse-url' after posting."
+  :type 'boolean
+  :group 'gist)
 
 (defcustom gist-multiple-files-mark "+"
-  "Symbol to use to indicate multiple-files gist")
+  "Symbol to use to indicate gists with multiple files."
+  :type 'string
+  :group 'gist)
 
 (defcustom gist-ask-for-description nil
-  "If non-nil, ask for a description before submitting
-  the gist.")
+  "If non-nil, prompt for description before submitting gist."
+  :type 'boolean
+  :group 'gist)
 
-(defvar gist-supported-modes-alist '((action-script-mode . "as")
-                                     (c-mode . "c")
-                                     (c++-mode . "cpp")
-                                     (clojure-mode . "clj")
-                                     (common-lisp-mode . "lisp")
-                                     (css-mode . "css")
-                                     (diff-mode . "diff")
-                                     (emacs-lisp-mode . "el")
-                                     (lisp-interaction-mode . "el")
-                                     (erlang-mode . "erl")
-                                     (haskell-mode . "hs")
-                                     (html-mode . "html")
-                                     (io-mode . "io")
-                                     (java-mode . "java")
-                                     (javascript-mode . "js")
-                                     (jde-mode . "java")
-                                     (js2-mode . "js")
-                                     (lua-mode . "lua")
-                                     (ocaml-mode . "ml")
-                                     (objective-c-mode . "m")
-                                     (perl-mode . "pl")
-                                     (php-mode . "php")
-                                     (python-mode . "py")
-                                     (ruby-mode . "rb")
-                                     (text-mode . "txt")
-                                     (scala-mode . "scala")
-                                     (sql-mode . "sql")
-                                     (scheme-mode . "scm")
-                                     (smalltalk-mode . "st")
-                                     (sh-mode . "sh")
-                                     (tcl-mode . "tcl")
-                                     (tex-mode . "tex")
-                                     (xml-mode . "xml")))
+(defcustom gist-supported-modes-alist '((action-script-mode . "as")
+                                        (c-mode . "c")
+                                        (c++-mode . "cpp")
+                                        (clojure-mode . "clj")
+                                        (common-lisp-mode . "lisp")
+                                        (css-mode . "css")
+                                        (diff-mode . "diff")
+                                        (emacs-lisp-mode . "el")
+                                        (lisp-interaction-mode . "el")
+                                        (erlang-mode . "erl")
+                                        (haskell-mode . "hs")
+                                        (html-mode . "html")
+                                        (io-mode . "io")
+                                        (java-mode . "java")
+                                        (javascript-mode . "js")
+                                        (jde-mode . "java")
+                                        (js2-mode . "js")
+                                        (lua-mode . "lua")
+                                        (ocaml-mode . "ml")
+                                        (objective-c-mode . "m")
+                                        (perl-mode . "pl")
+                                        (php-mode . "php")
+                                        (python-mode . "py")
+                                        (ruby-mode . "rb")
+                                        (text-mode . "txt")
+                                        (scala-mode . "scala")
+                                        (sql-mode . "sql")
+                                        (scheme-mode . "scm")
+                                        (smalltalk-mode . "st")
+                                        (sh-mode . "sh")
+                                        (tcl-mode . "tcl")
+                                        (tex-mode . "tex")
+                                        (xml-mode . "xml"))
+  "Mapping between major-modes and file extensions.
+Used to generate filenames for created gists, and to select
+appropriate modes from fetched gist files (based on filenames)."
+  :type '(alist :key-type   (symbol :tag "Mode")
+                :value-type (string :tag "Extension")))
 
 (defvar gist-list-db nil)
 


### PR DESCRIPTION
- Improve doc strings to match Emacs conventions.

  First line should be a complete sentence, including proper
  punctuation.

- Add all items to `gist` group.

- Add proper `:type` parameters.

  Enables type-specific input widgets--like toggle buttons--and improved
  display of values.

- Make `gist-supported-modes-alist` customizable.