### PR TITLE
Fixes #74 Updated gist-edit-current-description

### DIFF
--- a/gist.el
+++ b/gist.el
@@ -460,7 +460,6 @@ for the gist."
     (let* ((old-descr (oref gist :description))
            (new-descr (read-from-minibuffer "Description: " old-descr))
            (g (clone gist
-                     :files nil
                      :description new-descr))
            (resp (gh-gist-edit api g)))
       (gh-url-add-response-callback resp


### PR DESCRIPTION
Originally I thought sigma/gh.el#64 was enough to fix #74, but I had forgotten I had made this one small change to *gist.el*.
* * *
Changed `clone` call to not set :files to nil.

This combined with sigma/gh.el#64 fixes #74.