### PR TITLE
Fix yanking URL from gist-list buffer

### DIFF
--- a/gist.el
+++ b/gist.el
@@ -538,8 +538,8 @@ for the gist."
 
 (defun gist-current-url ()
   "Helper function to fetch current gist url"
-  (let* ((id (or (and (boundp 'gist-list-mode)
-                      gist-list-mode
+  (let* ((id (or (and (fboundp 'gist-list-mode)
+                      (eq major-mode 'gist-list-mode)
                       (tabulated-list-get-id))
                  (and (boundp 'gist-mode)
                       gist-mode

--- a/gist.el
+++ b/gist.el
@@ -538,8 +538,7 @@ for the gist."
 
 (defun gist-current-url ()
   "Helper function to fetch current gist url"
-  (let* ((id (or (and (fboundp 'gist-list-mode)
-                      (eq major-mode 'gist-list-mode)
+  (let* ((id (or (and (eq major-mode 'gist-list-mode)
                       (tabulated-list-get-id))
                  (and (boundp 'gist-mode)
                       gist-mode


### PR DESCRIPTION
This fixes 952048407e0bcd19bbe7e3a591ecbc0586a04abc.