### PR TITLE
Remove ‘require dired’ usage

### DIFF
--- a/gist.el
+++ b/gist.el
@@ -776,13 +776,20 @@ put it into `kill-ring'."
 
 ;;; Dired integration
 
-(require 'dired)
-
 (defun dired-do-gist (&optional private)
   (interactive "P")
   (gist-files (dired-get-marked-files) private))
 
-(define-key dired-mode-map "@" 'dired-do-gist)
+;;;###autoload
+(define-minor-mode gist-dired-mode
+  "Minor mode for using gist within dired.
+
+\\{gist-dired-mode-map}"
+  :keymap (let ((map (make-sparse-keymap)))
+	    (define-key map "@" 'dired-do-gist)
+	    map)
+  (unless (derived-mode-p 'dired-mode)
+    (setq gist-dired-mode nil)))
 
 (provide 'gist)
 ;;; gist.el ends here


### PR DESCRIPTION
Gist is causing a slow down in my configuration. It looks like it is from requiring dired. Hopefully this is an okay solution?

Instead to get the ‘@’ key in dired-mode to work,
you must now enable the new ‘gist-dired-mode’. To use just do add a hook
in dired-mode like this:

```
(add-hook 'dired-mode-hook 'gist-dired-mode)
```

This is possible to setup through use-package:

```
(use-package gist
  :ensure nil
  :commands gist-mode
  :hook (dired-mode . gist-dired-mode))
```