### PR TITLE
Fix issues with Emacs 29 compatibility

### DIFF
--- a/gist.el
+++ b/gist.el
@@ -810,19 +810,18 @@ With NEW-NAME rename gist."
     map))
 
 (define-minor-mode gist-mode
-  "Minor mode for buffers containing gists files"
+  "Minor mode for buffers containing gists files."
   :lighter " gist"
   :map 'gist-mode-map)
 
 ;;; Dired integration
 
-(require 'dired)
-
-(defun dired-do-gist (&optional private)
+(defun gist-dired-do-gist (&optional private)
+  "Create gist from marked files in `dired'.
+If PRIVATE is non-nil, create private gists."
   (interactive "P")
+  (require 'dired)
   (gist-files (dired-get-marked-files) private))
-
-(define-key dired-mode-map "@" 'dired-do-gist)
 
 (provide 'gist)
 ;;; gist.el ends here


### PR DESCRIPTION

- use `cl-lib` instead of deprecated `cl`
- enable lexical bindings
- fix `eieio` issues
- rename `dired-do-gist` to `gist-dired-do-gist`
- remove overriding `dired` keymap
- fix all byte-compile warnings
- add more documentation strings

**Important Note**
> New changes require [merge request](https://github.com/sigma/gh.el/pull/112) in `gh.el` to be merged first. 

